### PR TITLE
Implement new permission classes throughout app

### DIFF
--- a/backend/ai/views.py
+++ b/backend/ai/views.py
@@ -1,16 +1,18 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from .serializers import AIFeedbackSerializer
-from rest_framework.permissions import IsAuthenticated
+from accounts.permissions import IsReadOnlyOrAbove
+from accounts.mixins import CombinedOrgMixin
 
-class AIFeedbackView(APIView):
-    permission_classes = [IsAuthenticated]
+class AIFeedbackView(CombinedOrgMixin, APIView):
+    permission_classes = [IsReadOnlyOrAbove]
 
     def post(self, request):
         serializer = AIFeedbackSerializer(data=request.data)
         if serializer.is_valid():
             feedback = serializer.save(
                 user=request.user,
+                org=request.user.org,
                 can_affect_model=getattr(request.user, 'allow_feedback_to_train_model', False)
             )
             return Response({"message": "Feedback saved."}, status=201)

--- a/backend/analytics/models.py
+++ b/backend/analytics/models.py
@@ -1,19 +1,29 @@
 from django.db import models
 from django.contrib.auth import get_user_model
 from django.db.models import JSONField
+from accounts.models import Organization
 
 User = get_user_model()
 
 class AnalyticsDashboard(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE, related_name='dashboards')
+    org = models.ForeignKey(
+        Organization, 
+        on_delete=models.CASCADE, 
+        related_name='dashboards',
+        help_text="Organization this dashboard belongs to"
+    )
     name = models.CharField(max_length=100, default="My Dashboard")
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
     # Optionally: layout config for overall dashboard (grid, custom layouts, etc)
     layout = models.JSONField(default=list, blank=True)
 
+    class Meta:
+        unique_together = [['user', 'org', 'name']]
+
     def __str__(self):
-        return f"{self.user.username} - {self.name}"
+        return f"{self.user.username} - {self.name} ({self.org.name})"
 
 class DashboardChart(models.Model):
     dashboard = models.ForeignKey(AnalyticsDashboard, on_delete=models.CASCADE, related_name='charts')
@@ -35,4 +45,4 @@ class DashboardChart(models.Model):
     # Optionally: unique_together = [dashboard, position] for no overlaps
 
     def __str__(self):
-        return f"{self.chart_type} ({self.title})"
+        return f"{self.chart_type} ({self.title}) - {self.dashboard.org.name}"

--- a/backend/datagrid/models.py
+++ b/backend/datagrid/models.py
@@ -1,9 +1,17 @@
 from django.db import models
 from django.contrib.auth import get_user_model
+from accounts.models import Organization
+
 User = get_user_model()
 
 class UserTableSchema(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE, related_name="table_schemas")
+    org = models.ForeignKey(
+        Organization, 
+        on_delete=models.CASCADE, 
+        related_name='table_schemas',
+        help_text="Organization this table schema belongs to"
+    )
     table_name = models.CharField(max_length=128)
     db_table_name = models.CharField(max_length=128, blank=True, null=True)
     primary_key = models.CharField(max_length=128, default="id")
@@ -12,20 +20,50 @@ class UserTableSchema(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
 
     class Meta:
-        unique_together = ("user", "table_name")
+        unique_together = ("user", "org", "table_name")
+
+    def save(self, *args, **kwargs):
+        # Auto-assign org from user if not set
+        if not self.org and self.user and self.user.org:
+            self.org = self.user.org
+        super().save(*args, **kwargs)
 
     def __str__(self):
-        return f"{self.user.email or self.user.username} - {self.table_name} schema"
+        return f"{self.user.email or self.user.username} - {self.table_name} schema ({self.org.name})"
 
 class UserTableRow(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE)
+    org = models.ForeignKey(
+        Organization, 
+        on_delete=models.CASCADE, 
+        related_name='table_rows',
+        help_text="Organization this table row belongs to"
+    )
     table_name = models.CharField(max_length=128)
     data = models.JSONField(default=dict)
     created_at = models.DateTimeField(auto_now_add=True)
     modified_at = models.DateTimeField(auto_now=True)
 
+    class Meta:
+        ordering = ['-created_at']
+
+    def save(self, *args, **kwargs):
+        # Auto-assign org from user if not set
+        if not self.org and self.user and self.user.org:
+            self.org = self.user.org
+        super().save(*args, **kwargs)
+
+    def __str__(self):
+        return f"{self.table_name} row by {self.user.username} ({self.org.name})"
+
 class UserGridConfig(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE)
+    org = models.ForeignKey(
+        Organization, 
+        on_delete=models.CASCADE, 
+        related_name='grid_configs',
+        help_text="Organization this grid config belongs to"
+    )
     table_name = models.CharField(max_length=128)
     column_order = models.JSONField(default=list, blank=True)
     column_widths = models.JSONField(default=dict, blank=True)
@@ -35,5 +73,14 @@ class UserGridConfig(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
 
     class Meta:
-        unique_together = ("user", "table_name")
+        unique_together = ("user", "org", "table_name")
+
+    def save(self, *args, **kwargs):
+        # Auto-assign org from user if not set
+        if not self.org and self.user and self.user.org:
+            self.org = self.user.org
+        super().save(*args, **kwargs)
+
+    def __str__(self):
+        return f"{self.table_name} config by {self.user.username} ({self.org.name})"
 

--- a/backend/datagrid/views/reference.py
+++ b/backend/datagrid/views/reference.py
@@ -1,7 +1,8 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
-from rest_framework.permissions import IsAuthenticated
 from api.models import Customer, Product, Supplier, Warehouse, Shipment, Order  # Add as needed
+from accounts.permissions import IsReadOnlyOrAbove
+from accounts.mixins import CombinedOrgMixin
 
 REF_MODELS = {
     "customers": Customer,
@@ -13,11 +14,19 @@ REF_MODELS = {
     # Add any other models you want to expose as reference options
 }
 
-class ReferenceOptionsView(APIView):
-    permission_classes = [IsAuthenticated]
+class ReferenceOptionsView(CombinedOrgMixin, APIView):
+    permission_classes = [IsReadOnlyOrAbove]
+    
     def get(self, request, table_name):
         Model = REF_MODELS.get(table_name)
         if not Model:
             return Response({"error": "Invalid table"}, status=400)
-        data = list(Model.objects.all().values("id", "name"))
+        
+        # CombinedOrgMixin ensures org filtering
+        # Filter data by user's organization
+        if hasattr(Model, 'org'):
+            data = list(Model.objects.filter(org=request.user.org).values("id", "name"))
+        else:
+            # Fallback for models without org field (legacy)
+            data = list(Model.objects.all().values("id", "name"))
         return Response(data)

--- a/backend/datagrid/views/row.py
+++ b/backend/datagrid/views/row.py
@@ -1,37 +1,56 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
-from rest_framework.permissions import IsAuthenticated
 from datagrid.models import UserTableRow
 from datagrid.serializers import UserTableRowSerializer
 from django.shortcuts import get_object_or_404
+from accounts.permissions import IsReadOnlyOrAbove
+from accounts.mixins import CombinedOrgMixin
 
-class UserTableRowListCreateView(APIView):
-    permission_classes = [IsAuthenticated]
+class UserTableRowListCreateView(CombinedOrgMixin, APIView):
+    permission_classes = [IsReadOnlyOrAbove]
 
     def get(self, request, table_name):
-        rows = UserTableRow.objects.filter(user=request.user, table_name=table_name)
+        # CombinedOrgMixin ensures org filtering
+        rows = UserTableRow.objects.filter(
+            user=request.user, 
+            org=request.user.org, 
+            table_name=table_name
+        )
         serializer = UserTableRowSerializer(rows, many=True)
         return Response(serializer.data)
 
     def post(self, request, table_name):
         row = UserTableRow.objects.create(
             user=request.user,
+            org=request.user.org,
             table_name=table_name,
             data=request.data.get('data', {}),
         )
         return Response(UserTableRowSerializer(row).data, status=201)
 
-class UserTableRowDetailView(APIView):
-    permission_classes = [IsAuthenticated]
+class UserTableRowDetailView(CombinedOrgMixin, APIView):
+    permission_classes = [IsReadOnlyOrAbove]
 
     def patch(self, request, table_name, pk):
-        row = get_object_or_404(UserTableRow, user=request.user, table_name=table_name, pk=pk)
+        row = get_object_or_404(
+            UserTableRow, 
+            user=request.user, 
+            org=request.user.org, 
+            table_name=table_name, 
+            pk=pk
+        )
         for k, v in request.data.get('data', {}).items():
             row.data[k] = v
         row.save()
         return Response(UserTableRowSerializer(row).data)
 
     def delete(self, request, table_name, pk):
-        row = get_object_or_404(UserTableRow, user=request.user, table_name=table_name, pk=pk)
+        row = get_object_or_404(
+            UserTableRow, 
+            user=request.user, 
+            org=request.user.org, 
+            table_name=table_name, 
+            pk=pk
+        )
         row.delete()
         return Response({"success": True})

--- a/backend/datagrid/views/user_grid_config.py
+++ b/backend/datagrid/views/user_grid_config.py
@@ -2,18 +2,23 @@
 
 from rest_framework.views import APIView
 from rest_framework.response import Response
-from rest_framework.permissions import IsAuthenticated
 from rest_framework import status
 from datagrid.models import UserGridConfig
 from datagrid.serializers import UserGridConfigSerializer
 from django.shortcuts import get_object_or_404
+from accounts.permissions import IsReadOnlyOrAbove
+from accounts.mixins import CombinedOrgMixin
 
-class UserGridConfigView(APIView):
-    permission_classes = [IsAuthenticated]
+class UserGridConfigView(CombinedOrgMixin, APIView):
+    permission_classes = [IsReadOnlyOrAbove]
 
     def get(self, request, table_name):
         """Get the current user's grid config for a table."""
-        config = UserGridConfig.objects.filter(user=request.user, table_name=table_name).first()
+        config = UserGridConfig.objects.filter(
+            user=request.user, 
+            org=request.user.org, 
+            table_name=table_name
+        ).first()
         if not config:
             # Return sensible defaults if config doesn't exist yet
             return Response({"detail": "No config yet."}, status=404)
@@ -22,7 +27,11 @@ class UserGridConfigView(APIView):
 
     def patch(self, request, table_name):
         """Update grid config for this table."""
-        config, _ = UserGridConfig.objects.get_or_create(user=request.user, table_name=table_name)
+        config, _ = UserGridConfig.objects.get_or_create(
+            user=request.user, 
+            org=request.user.org, 
+            table_name=table_name
+        )
         serializer = UserGridConfigSerializer(config, data=request.data, partial=True)
         if serializer.is_valid():
             serializer.save()


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implement organization-based RBAC by adding `org` fields to models and applying new permission classes to views.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR systematically integrates organization-based access control throughout the application. It adds `org` foreign keys to relevant models (AI feedback, analytics, datagrid, files) to scope data by organization, updates model `save` methods for auto-assignment, and modifies views to filter data by the user's organization. New, more granular permission classes (`IsReadOnlyOrAbove`, `CanViewAnalytics`, `CanManageOrganization`) are applied to enforce proper RBAC, replacing generic `IsAuthenticated` or `AllowAny`.